### PR TITLE
Adding AM_PROG_CC_C_O to configure.ac to avoid error: compiling 'main…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_SILENT_RULES([yes])
 # Checks for programs.
 AC_PROG_MKDIR_P
 AC_PROG_CC
+AM_PROG_CC_C_O
 
 # Rules locations
 AC_ARG_WITH([rulesdir],


### PR DESCRIPTION
The fix is for:

```
$ ./autogen.sh
Running "mkdir build-aux" ... OK
Running "aclocal -I m4" ... OK
Running "autoheader" ... OK
Running "autoconf" ... OK
Running "automake --add-missing --copy" ... FAILED
An error occured, the output below can be found in autogen.log
-------
$ mkdir build-aux
$ aclocal -I m4
$ autoheader
$ autoconf
$ automake --add-missing --copy
configure.ac:11: installing 'build-aux/install-sh'
configure.ac:11: installing 'build-aux/missing'
automake: warnings are treated as errors
Makefile.am:27: warning: compiling 'main.c' with per-target flags requires 'AM_PROG_CC_C_O' in 'configure.ac'
Makefile.am: installing 'build-aux/depcomp'


```